### PR TITLE
Fix the narrowing of Any types to enum literals

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from collections import defaultdict
+from mypy.typeops import make_simplified_union
 
 from typing import Dict, List, Set, Iterator, Union, Optional, Tuple, cast
 from typing_extensions import DefaultDict
@@ -195,7 +196,12 @@ class ConditionalTypeBinder:
             type = resulting_values[0]
             assert type is not None
             declaration_type = get_proper_type(self.declarations.get(key))
-            if isinstance(declaration_type, AnyType):
+
+            if current_value and is_same_type(
+                    make_simplified_union(cast(List[Type], resulting_values)), current_value
+                    ):
+                type = current_value
+            elif isinstance(declaration_type, AnyType):
                 # At this point resulting values can't contain None, see continue above
                 if not all(is_same_type(type, cast(Type, t)) for t in resulting_values[1:]):
                     type = AnyType(TypeOfAny.from_another_any, source_any=declaration_type)

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1073,3 +1073,35 @@ def f(t: Type[C]) -> None:
     else:
         reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
     reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+
+[case testNarrowingAny]
+# Regression test: The third reveal type would show z to be
+# typed as Any, despite the `isinstance` assertion.
+
+from enum import Enum
+from typing import Any
+
+class Foo(Enum):
+    A = 1
+    B = 2
+    C = 3
+
+z: Any
+
+assert isinstance(z, Foo)
+reveal_type(z)  # N: Revealed type is "__main__.Foo"
+
+if z is Foo.A:
+    reveal_type(z)  # N: Revealed type is "Literal[__main__.Foo.A]"
+reveal_type(z)  # N: Revealed type is "__main__.Foo"
+
+q: Any
+
+assert isinstance(q, (tuple, list))
+reveal_type(q)  # N: Revealed type is "Union[builtins.tuple[Any], builtins.list[Any]]"
+
+if isinstance(q, tuple):
+    reveal_type(q)  # N: Revealed type is "builtins.tuple[Any]"
+reveal_type(q)  # N: Revealed type is "Union[builtins.tuple[Any], builtins.list[Any]]"
+
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
The type binder would treat the literals of enums as disjoint types and
fall back to the Any type, now there is an explicit check for narrowing
sum types.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
